### PR TITLE
[ESW-519] ABR 2.0 Algorithm Fixes Part 2 (rpeak resolution and latch limits)

### DIFF
--- a/abr_algo_standalone/myant/abr_postprocess.c
+++ b/abr_algo_standalone/myant/abr_postprocess.c
@@ -9,7 +9,7 @@
 #define ABR_RPEAK_THRESHOLD_MIN_CHEST   -1.7f   // Chest threshold (see ALDD)
 #define ABR_RPEAK_THRESHOLD_MIN_UDW     -1.8f   // Underwear threshold (see ALDD)
 #define ABR_RPEAK_PREDICTION_MAX        3.0f
-#define ABR_RPEAK_RESOLUTION            31.0f
+#define ABR_RPEAK_RESOLUTION          30.0f    // 31 bits, 0 is no rpeak, so 30 bits
 
 // Structure definitions
 typedef struct

--- a/abr_algo_standalone/myant/abr_preprocess.c
+++ b/abr_algo_standalone/myant/abr_preprocess.c
@@ -12,6 +12,13 @@
 #define FILTER_LEN_ECG           3
 #define SOFTNESS_FILTER_LEN      12
 
+// Latch defitions
+#define LATCH_LIMIT_LOW_CHEST    0.15f    // Chest low limit (see ALDD)
+#define LATCH_LIMIT_HIGH_CHEST   1.2f     // Chest high limit (see ALDD)
+
+#define LATCH_LIMIT_LOW_UDW      0.15f    // UDW low limit (see ALDD)
+#define LATCH_LIMIT_HIGH_UDW     0.3f     // UDW high limit (see ALDD)
+
 // Notch filter definitions
 #define NOTCH_FILTER_SIZE        5
 #define NOTCH_FILTER_COEFF_LEN_A 5
@@ -54,6 +61,8 @@ static quality_t quality_info[MAX_ECG] = {0};
 static bool      filter_restart        = false;
 
 static float abr_ecg_process(float sample, ecg_sens_id ecg_id, bool restart);
+static float     dLatchLimitLow  = 0.0f;
+static float     dLatchLimitHigh = 0.0f;
 static uint8_t latch_sigmoid(float sample, ecg_sens_id ecg_id);
 static float softness_filter(float sample, uint8_t ecg_ch, bool restart);
 static void abr_quality_slope(float sample, ecg_sens_id ecg_id, float *sample_diff, bool restart);
@@ -178,11 +187,11 @@ static uint8_t latch_sigmoid(float quality, ecg_sens_id ecg_id)
 {
     static uint8_t latch_q[MAX_ECG] = {0, 0, 0};
 
-    if (quality > 1.2)
+    if (quality > dLatchLimitHigh)
     {
         latch_q[ecg_id] = 1;
     }
-    else if (quality < 0.15)
+    else if (quality < dLatchLimitLow)
     {
         latch_q[ecg_id] = 0;
     }
@@ -330,3 +339,26 @@ float ABRPreProcess_GetOutput(float x, uint8_t ecg_ch, bool restart, garment_id_
     return processed_ecg[ecg_ch];
 }
 
+/*
+ * @brief  This function is used update quality latch limits accessed by
+ * latch_sigmoid.
+ * @param  nID - the garment ID, represents which garment is used
+ * @detail The aim of this function is to update the latch limits for quality
+ * based on garment type.
+ * @retval no return type
+ */
+void ABRPreProcess_SetLatchLimits(garment_id_e nID)
+{
+    if (nID == GARMENT_UNDERWEAR)
+    {
+        dLatchLimitLow  = LATCH_LIMIT_LOW_UDW;
+        dLatchLimitHigh = LATCH_LIMIT_HIGH_UDW;
+    }
+    else
+    {
+        dLatchLimitLow  = LATCH_LIMIT_LOW_CHEST;
+        dLatchLimitHigh = LATCH_LIMIT_HIGH_CHEST;
+    }
+
+    return;
+}

--- a/abr_algo_standalone/myant/abr_preprocess.c
+++ b/abr_algo_standalone/myant/abr_preprocess.c
@@ -60,9 +60,10 @@ static notch_fq  notch_cnf_fq_flag     = FQ_60HZ;
 static quality_t quality_info[MAX_ECG] = {0};
 static bool      filter_restart        = false;
 
-static float abr_ecg_process(float sample, ecg_sens_id ecg_id, bool restart);
 static float     dLatchLimitLow  = 0.0f;
 static float     dLatchLimitHigh = 0.0f;
+
+static float   abr_ecg_process(float sample, ecg_sens_id ecg_id, bool restart);
 static uint8_t latch_sigmoid(float sample, ecg_sens_id ecg_id);
 static float softness_filter(float sample, uint8_t ecg_ch, bool restart);
 static void abr_quality_slope(float sample, ecg_sens_id ecg_id, float *sample_diff, bool restart);

--- a/abr_algo_standalone/myant/abr_preprocess.h
+++ b/abr_algo_standalone/myant/abr_preprocess.h
@@ -38,5 +38,6 @@ typedef enum
 float ABRPreProcess_GetOutput(float x, uint8_t ecg_ch, bool restart, garment_id_e gar_id);
 void ABRPreProcess_GetQuality(ecg_sens_id ecg_id, uint8_t *q_class, uint8_t *slope);
 void ABRPreProcess_SetNotchFilterCoeffient(bool freq_update);
+void ABRPreProcess_SetLatchLimits(garment_id_e nID);
 
 #endif /* ABR_PREPROCESS_H_ */

--- a/abr_algo_standalone/myant/ecg_algo.cpp
+++ b/abr_algo_standalone/myant/ecg_algo.cpp
@@ -40,6 +40,9 @@ void ECGAlgo_SetGarmentID(garment_id_e nID)
     // 4) Update rpeak threshold + range in post processor
     ABRPostProcess_SetRPeak(nID);
 
+    // 5) Update Quality Latch Limits in abr_preprocess.c
+    ABRPreProcess_SetLatchLimits(nID);
+
     return;
 }
 


### PR DESCRIPTION
# Summary
Match fw implementation to python implementation. Fix ABR_RPEAK_RESOLUTION to be 30 bits not 31. Set latch limits based on garment type.

# Added
None

# Changed
'abr_postprocess.c' - changed ABR_RPEAK_RESOLUTION to be 30 not 31
'abr_preprocess.c' - added different latch limits per garment id
'abr_preprocess.h' - added function definition to set latch limits based on garment id
'ecg_algo.cpp' - call ABRPreProcess_SetLatchLimits when garment id is set

# Removed
- N/A

# Testing
- 8 example trials were tested to compare between python and c outputs to ensure they match, report in RDR510 ABR fw standalone evaluation
- 5 trials of chest data
- 3 trials of underwear data


# Automated Testing (Currently Not Used)
- N/A