### PR TITLE
[ESW-591] Integrate Updated Bit Reduction Implementation

### DIFF
--- a/ecg_bit_reduction/ecg_bit_reduction.c
+++ b/ecg_bit_reduction/ecg_bit_reduction.c
@@ -1,10 +1,11 @@
-#include <stdio.h>
-#include <stdbool.h>
-#include <string.h>
-#include <stdlib.h>
-#include <math.h>
 #include "ecg_bit_reduction.h"
+#include "csv_writers.h"
 #include "data_processing.h"
+#include <math.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 // --- Defines and macros ---
 
@@ -37,9 +38,9 @@
 
 // --- Globals ---
 
-static const double gflHighpassCoeffiecientsA[] = {1.0l,                 -1.9991669594972l,  0.9991673063310l};
-static const double gflHighpassCoeffiecientsB[] = {0.99958356645707l,    -1.99916713291414l, 0.99958356645705l};
-static double gflHighpassInput[MAX_ECG][HP_FILTER_SIZE] = {0};
+static const double gflHighpassCoeffiecientsA[] = {1.f, -1.999167f, 0.9991673f};
+static const double gflHighpassCoeffiecientsB[] = {0.9995835f, -1.999167f, 0.9995835f};
+static double gflHighpassInput[MAX_ECG][HP_FILTER_SIZE]  = {0};
 static double gflHighpassOutput[MAX_ECG][HP_FILTER_SIZE] = {0};
 
 static double gflMeanValue[MAX_ECG] = {0};
@@ -140,6 +141,8 @@ static double ECGBitReduction_MSBRemoval(uint32_t bSample, ecg_sens_id nECGId, b
     flProcessedMSB = ecgbr_digital_filter((double)bSample, gflHighpassInput[nECGId], gflHighpassOutput[nECGId], gflHighpassCoeffiecientsA, gflHighpassCoeffiecientsB, 
         HP_FILTER_COEFF_LEN_A, HP_FILTER_COEFF_LEN_B, HP_FILTER_SIZE, gfResetFlagECG[nECGId], (double)bSample);
     
+    CSVW_WriteCSVSingle("3_filter_inp.csv", (float)bSample, 2);
+    CSVW_WriteCSVSingle("1_filter.csv", flProcessedMSB, 2);
     // Reset flt flag
     gfResetFlagECG[nECGId] = false;
     

--- a/ecg_bit_reduction/ecg_bit_reduction.c
+++ b/ecg_bit_reduction/ecg_bit_reduction.c
@@ -38,10 +38,10 @@
 
 // --- Globals ---
 
-static const double gflHighpassCoeffiecientsA[] = {1.f, -1.999167f, 0.9991673f};
-static const double gflHighpassCoeffiecientsB[] = {0.9995835f, -1.999167f, 0.9995835f};
-static double gflHighpassInput[MAX_ECG][HP_FILTER_SIZE]  = {0};
-static double gflHighpassOutput[MAX_ECG][HP_FILTER_SIZE] = {0};
+static const float gflHighpassCoeffiecientsA[] = {1.f, -1.999167f, 0.9991673f};
+static const float gflHighpassCoeffiecientsB[] = {0.9995835f, -1.999167f, 0.9995835f};
+static float gflHighpassInput[MAX_ECG][HP_FILTER_SIZE]  = {0};
+static float gflHighpassOutput[MAX_ECG][HP_FILTER_SIZE] = {0};
 
 static double gflMeanValue[MAX_ECG] = {0};
 static uint32_t gbPreviousECG[MAX_ECG] = {0};
@@ -137,12 +137,10 @@ static double ECGBitReduction_MSBRemoval(uint32_t bSample, ecg_sens_id nECGId, b
     // Check_restart
     gfResetFlagECG[nECGId] = ECGBitReduction_CheckRestartFilter(bSample, nECGId, fRestart);
 
-    // Filter data - XXX remove ecgbr_digital_filter() and replace with standard float-based digital_filter function
-    flProcessedMSB = ecgbr_digital_filter((double)bSample, gflHighpassInput[nECGId], gflHighpassOutput[nECGId], gflHighpassCoeffiecientsA, gflHighpassCoeffiecientsB, 
-        HP_FILTER_COEFF_LEN_A, HP_FILTER_COEFF_LEN_B, HP_FILTER_SIZE, gfResetFlagECG[nECGId], (double)bSample);
-    
-    CSVW_WriteCSVSingle("3_filter_inp.csv", (float)bSample, 2);
-    CSVW_WriteCSVSingle("1_filter.csv", flProcessedMSB, 2);
+    // Filter data
+    flProcessedMSB = digital_filter((float)bSample, gflHighpassInput[nECGId], gflHighpassOutput[nECGId], gflHighpassCoeffiecientsA, gflHighpassCoeffiecientsB, HP_FILTER_COEFF_LEN_A, HP_FILTER_COEFF_LEN_B, HP_FILTER_SIZE, gfResetFlagECG[nECGId], (float)bSample);
+    CSVW_WriteCSVSingle("1_filter_float.csv", flProcessedMSB, 2);
+
     // Reset flt flag
     gfResetFlagECG[nECGId] = false;
     

--- a/ecg_bit_reduction/ecg_bit_reduction.c
+++ b/ecg_bit_reduction/ecg_bit_reduction.c
@@ -145,7 +145,6 @@ static float ECGBitReduction_MSBRemoval(uint32_t bSample, ecg_sens_id nECGId, bo
 
     // Filter data
     flProcessedMSB = digital_filter((float)bSample, gflHighpassInput[nECGId], gflHighpassOutput[nECGId], gflHighpassCoeffiecientsA, gflHighpassCoeffiecientsB, HP_FILTER_COEFF_LEN_A, HP_FILTER_COEFF_LEN_B, HP_FILTER_SIZE, gfResetFlagECG[nECGId], (float)bSample);
-    CSVW_WriteCSVSingle("1_filter_float.csv", flProcessedMSB, 2);
 
     // Reset flt flag
     gfResetFlagECG[nECGId] = false;

--- a/ecg_bit_reduction/main.c
+++ b/ecg_bit_reduction/main.c
@@ -9,42 +9,48 @@
 
 int main(int argc, const char *argv[])
 {
-    // Inputs
+    /* Inputs */
     float dpInput1[MAX_ROWS] = {0};
     float dpInput2[MAX_ROWS] = {0};
     float dpInput3[MAX_ROWS] = {0};
     int   bNumRows           = 0;
 
-    // Intermediate data
-    bool fECGBufferRefresh = true;    // apply whenever pod is reset, or there
-                                      // is missing data
+    /* Intermediate data */
     int16_t bECGReducedData = 0;
+    /* fECGBufferRefresh=true whenever pod is reset, or there is missing data*/
+    bool    fECGBufferRefresh = true;
 
-    // Read Inputs from CSV:
+    /* Read Inputs from CSV: */
     printf("Setting inputs...\r\n");
     CSVW_ReadCSV(INPUT_FILE_NAME, dpInput1, dpInput2, dpInput3, &bNumRows);
 
-    // Loop through entire input array
+    /* Loop through entire input array */
     printf("Looping through input data...\r\n\r\n");
     for (uint32_t i = 0; i < bNumRows; i++)
     {
-        // ECG Bit Reduction Algorithm
+        /* ECG Bit Reduction Algorithm */
         bECGReducedData = ECGBitReduction_SampleReduction((uint32_t)dpInput1[i], ECG1, fECGBufferRefresh);
-        CSVW_WriteCSVSingle("in_all.csv", dpInput1[i], ECG1);
-        CSVW_WriteCSVSingle("out_all.csv", (float)bECGReducedData, ECG1);
-        bECGReducedData = ECGBitReduction_SampleReduction((uint32_t)dpInput2[i], ECG2, fECGBufferRefresh);
-        CSVW_WriteCSVSingle("in_all.csv", dpInput2[i], ECG2);
-        CSVW_WriteCSVSingle("out_all.csv", (float)bECGReducedData, ECG2);
-        bECGReducedData = ECGBitReduction_SampleReduction((uint32_t)dpInput3[i], ECG3, fECGBufferRefresh);
-        CSVW_WriteCSVSingle("in_all.csv", dpInput3[i], ECG3);
+        CSVW_WriteCSVSingle("in_all.csv", dpInput1[i], ECG3);
         CSVW_WriteCSVSingle("out_all.csv", (float)bECGReducedData, ECG3);
+        /*
+        bECGReducedData =
+        ECGBitReduction_SampleReduction((uint32_t)dpInput2[i], ECG2,
+        fECGBufferRefresh); CSVW_WriteCSVSingle("in_all.csv", dpInput2[i],
+        ECG2); CSVW_WriteCSVSingle("out_all.csv", (float)bECGReducedData,
+        ECG2); bECGReducedData =
+        ECGBitReduction_SampleReduction((uint32_t)dpInput3[i], ECG3,
+        fECGBufferRefresh); CSVW_WriteCSVSingle("in_all.csv", dpInput3[i],
+        ECG3); CSVW_WriteCSVSingle("out_all.csv", (float)bECGReducedData,
+        ECG3);
+         */
 
-        // Write algorithm output to CSV
+        /* Write algorithm output to CSV  */
 
-        // Only refresh on the first iteration of the loop
+        /* Only refresh on the first iteration of the loop  */
         fECGBufferRefresh = false;
     }
 
     printf("Data set complete, exiting...\r\n");
     return 0;
 }
+

--- a/ecg_bit_reduction/main.c
+++ b/ecg_bit_reduction/main.c
@@ -10,10 +10,10 @@
 int main(int argc, const char *argv[])
 {
     // Inputs
-    float dpInput[MAX_ROWS] = {0};
-    float dpDummyInput1[2]  = {0};
-    float dpDummyInput2[2]  = {0};
-    int   bNumRows          = 0;
+    float dpInput1[MAX_ROWS] = {0};
+    float dpInput2[MAX_ROWS] = {0};
+    float dpInput3[MAX_ROWS] = {0};
+    int   bNumRows           = 0;
 
     // Intermediate data
     bool    fECGBufferRefresh = true;
@@ -21,18 +21,24 @@ int main(int argc, const char *argv[])
 
     // Read Inputs from CSV:
     printf("Setting inputs...\r\n");
-    CSVW_ReadCSV(INPUT_FILE_NAME, dpInput, dpDummyInput1, dpDummyInput2, &bNumRows);
+    CSVW_ReadCSV(INPUT_FILE_NAME, dpInput1, dpInput2, dpInput3, &bNumRows);
 
     // Loop through entire input array
     printf("Looping through input data...\r\n\r\n");
     for (uint32_t i = 0; i < bNumRows; i++)
     {
         // ECG Bit Reduction Algorithm
-        bECGReducedData = ECGBitReduction_SampleReduction((uint32_t)dpInput[i], ECG1, fECGBufferRefresh);
+        bECGReducedData = ECGBitReduction_SampleReduction((uint32_t)dpInput1[i], ECG1, fECGBufferRefresh);
+        CSVW_WriteCSVSingle("in_all.csv", dpInput1[i], ECG1);
+        CSVW_WriteCSVSingle("out_all.csv", (float)bECGReducedData, ECG1);
+        bECGReducedData = ECGBitReduction_SampleReduction((uint32_t)dpInput2[i], ECG2, fECGBufferRefresh);
+        CSVW_WriteCSVSingle("in_all.csv", dpInput2[i], ECG2);
+        CSVW_WriteCSVSingle("out_all.csv", (float)bECGReducedData, ECG2);
+        bECGReducedData = ECGBitReduction_SampleReduction((uint32_t)dpInput3[i], ECG3, fECGBufferRefresh);
+        CSVW_WriteCSVSingle("in_all.csv", dpInput3[i], ECG3);
+        CSVW_WriteCSVSingle("out_all.csv", (float)bECGReducedData, ECG3);
 
         // Write algorithm output to CSV
-        CSVW_WriteCSVSingle("in_ch1.csv", dpInput[i], ECG3);
-        CSVW_WriteCSVSingle("out1.csv", bECGReducedData, ECG3);
 
         // Only refresh on the first iteration of the loop
         fECGBufferRefresh = false;

--- a/ecg_bit_reduction/main.c
+++ b/ecg_bit_reduction/main.c
@@ -1,29 +1,27 @@
-#include "ecg_bit_reduction.h"
 #include "csv_writers.h"
+#include "ecg_bit_reduction.h"
 #include <math.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 
-#define ECG_DATA_BUFFER_SIZE         24
+#define ECG_DATA_BUFFER_SIZE 24
 
 int main(int argc, const char *argv[])
 {
     // Inputs
     float dpInput[MAX_ROWS] = {0};
+    float dpDummyInput1[2]  = {0};
+    float dpDummyInput2[2]  = {0};
     int   bNumRows          = 0;
 
     // Intermediate data
-    bool fECGBufferRefresh = true;
-    uint16_t bECGReducedData = 0;
-
-    // Write CSV header - TODO: Gloria
-    const char *pVarNames = "output";
-    CSVW_WriteCSVHeader("out.csv", pVarNames);
+    bool    fECGBufferRefresh = true;
+    int16_t bECGReducedData   = 0;
 
     // Read Inputs from CSV:
     printf("Setting inputs...\r\n");
-    CSVW_ReadCSV(INPUT_FILE_NAME, dpInput, NULL, NULL, &bNumRows);
+    CSVW_ReadCSV(INPUT_FILE_NAME, dpInput, dpDummyInput1, dpDummyInput2, &bNumRows);
 
     // Loop through entire input array
     printf("Looping through input data...\r\n\r\n");
@@ -32,8 +30,9 @@ int main(int argc, const char *argv[])
         // ECG Bit Reduction Algorithm
         bECGReducedData = ECGBitReduction_SampleReduction((uint32_t)dpInput[i], ECG1, fECGBufferRefresh);
 
-        // Write algorithm output to CSV 
-        CSVW_WriteCSVSingle("out.csv", bECGReducedData, ECG1);
+        // Write algorithm output to CSV
+        CSVW_WriteCSVSingle("in_ch1.csv", dpInput[i], ECG3);
+        CSVW_WriteCSVSingle("out1.csv", bECGReducedData, ECG3);
 
         // Only refresh on the first iteration of the loop
         fECGBufferRefresh = false;

--- a/ecg_bit_reduction/main.c
+++ b/ecg_bit_reduction/main.c
@@ -16,8 +16,9 @@ int main(int argc, const char *argv[])
     int   bNumRows           = 0;
 
     // Intermediate data
-    bool    fECGBufferRefresh = true;
-    int16_t bECGReducedData   = 0;
+    bool fECGBufferRefresh = true;    // apply whenever pod is reset, or there
+                                      // is missing data
+    int16_t bECGReducedData = 0;
 
     // Read Inputs from CSV:
     printf("Setting inputs...\r\n");

--- a/shared/data_processing.c
+++ b/shared/data_processing.c
@@ -1,5 +1,4 @@
 #include "data_processing.h"
-#include "csv_writers.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -11,56 +10,59 @@ float digital_filter(float dInput, float *pIn, float *pOut, const float *pA, con
     float output = 0.0f;
     float tmp    = 0.0f;
 
-    // 1) Check arguments - pointers
+    /* 1) Check arguments - pointers */
     if ((pA == NULL) || (pB == NULL) || (pIn == NULL) || (pOut == NULL))
     {
         return 0;
     }
 
-    // 2) Check arguments - lengths
+    /* 2) Check arguments - lengths */
     if ((bFilterOrder == 0) || (aLength == 0) || (bLength == 0) || (aLength > bFilterOrder) || (bLength > bFilterOrder))
     {
         return 0;
     }
 
-    // 3) If fReset was set, modify input data
+    /* 3) If fReset was set, modify input data */
     if (fReset)
     {
         for (uint8_t i = 0; i < bFilterOrder; i++)
         {
-            pIn[i] = dInitialSample;    // Initialize input buffer with initial
-                                        // sample
-            pOut[i] = 0;                // Initialize output buffer with zero
+            /* Initialize input buffer with initial sample */
+            pIn[i] = dInitialSample;
+
+            /* Initialize output buffer with zero */
+            pOut[i] = 0;
         }
     }
-    pIn[bFilterOrder - 1] = dInput;    // Place new input sample at the end of
-                                       // input buffer
 
-    // 4) Apply the feedforward coefficients to the input samples
+    /* Place new input sample at the end of input buffer */
+    pIn[bFilterOrder - 1] = dInput;
+
+    /* 4) Apply the feedforward coefficients to the input samples */
     for (uint8_t i = 0; i < bLength; i++)
     {
         tmp += pB[i] * pIn[bFilterOrder - 1 - i];
     }
 
-    // 5) Apply the feedback coefficients to the output samples
+    /* 5) Apply the feedback coefficients to the output samples */
     for (uint8_t i = 1; i < aLength; i++)
     {
         tmp -= pA[i] * pOut[bFilterOrder - 1 - i];
     }
 
-    // 6) Normalize by the first feedback coefficient
-    tmp                    /= pA[0];
-    output                  = tmp;
-    pOut[bFilterOrder - 1]  = output;
+    /* 6) Normalize by the first feedback coefficient */
+    tmp                    = tmp / pA[0];
+    output                 = tmp;
+    pOut[bFilterOrder - 1] = output;
 
-    // 7) Shift input and output buffers to make room for the next sample
+    /* 7) Shift input and output buffers to make room for the next sample */
     for (uint8_t i = 1; i < bFilterOrder; i++)
     {
         pIn[i - 1]  = pIn[i];
         pOut[i - 1] = pOut[i];
     }
 
-    // 8) Return the filtered output sample
+    /* 8) Return the filtered output sample */
     return output;
 }
 

--- a/shared/data_processing.c
+++ b/shared/data_processing.c
@@ -45,20 +45,20 @@ float digital_filter(float dInput, float *pIn, float *pOut, const float *pA, con
     // 5) Apply the feedback coefficients to the output samples
     for (uint8_t i = 1; i < aLength; i++)
     {
-        tmp -= pA[i] * pOut[bFilterOrder - i];
+        tmp -= pA[i] * pOut[bFilterOrder - 1 - i];
     }
 
-    // 6) Shift input and output buffers to make room for the next sample
+    // 6) Normalize by the first feedback coefficient
+    tmp                    /= pA[0];
+    output                  = tmp;
+    pOut[bFilterOrder - 1]  = output;
+
+    // 7) Shift input and output buffers to make room for the next sample
     for (uint8_t i = 1; i < bFilterOrder; i++)
     {
         pIn[i - 1]  = pIn[i];
         pOut[i - 1] = pOut[i];
     }
-
-    // 7) Normalize by the first feedback coefficient
-    tmp                    /= pA[0];
-    output                  = tmp;
-    pOut[bFilterOrder - 1]  = output;
 
     // 8) Return the filtered output sample
     return output;

--- a/shared/data_processing.c
+++ b/shared/data_processing.c
@@ -1,7 +1,9 @@
 #include "data_processing.h"
+#include "csv_writers.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 float digital_filter(float dInput, float *pIn, float *pOut, const float *pA, const float *pB, uint8_t aLength, uint8_t bLength, uint8_t bFilterOrder, bool fReset, float dInitialSample)
@@ -26,13 +28,15 @@ float digital_filter(float dInput, float *pIn, float *pOut, const float *pA, con
     {
         for (uint8_t i = 0; i < bFilterOrder; i++)
         {
-            pIn[i]  = dInitialSample;   // Initialize input buffer with initial sample
+            pIn[i] = dInitialSample;    // Initialize input buffer with initial
+                                        // sample
             pOut[i] = 0;                // Initialize output buffer with zero
         }
     }
-    pIn[bFilterOrder - 1] = dInput;     // Place new input sample at the end of input buffer
+    pIn[bFilterOrder - 1] = dInput;    // Place new input sample at the end of
+                                       // input buffer
 
-    // 4) Apply the feedforward coefficients to the input samples 
+    // 4) Apply the feedforward coefficients to the input samples
     for (uint8_t i = 0; i < bLength; i++)
     {
         tmp += pB[i] * pIn[bFilterOrder - 1 - i];
@@ -41,77 +45,22 @@ float digital_filter(float dInput, float *pIn, float *pOut, const float *pA, con
     // 5) Apply the feedback coefficients to the output samples
     for (uint8_t i = 1; i < aLength; i++)
     {
-        tmp -= pA[i] * pOut[bFilterOrder - 1 - i];
+        tmp -= pA[i] * pOut[bFilterOrder - i];
     }
 
-    // 6) Normalize by the first feedback coefficient 
-    tmp /= pA[0];
-    output = tmp;
-    pOut[bFilterOrder - 1]  = output;
-
-    // 7) Shift input and output buffers to make room for the next sample
+    // 6) Shift input and output buffers to make room for the next sample
     for (uint8_t i = 1; i < bFilterOrder; i++)
     {
         pIn[i - 1]  = pIn[i];
         pOut[i - 1] = pOut[i];
     }
 
-    // 8) Return the filtered output sample
-    return output;
-}
-
-double ecgbr_digital_filter(double dInput, double *pIn, double *pOut, const double *pA, const double *pB, uint8_t aLength, uint8_t bLength, uint8_t bFilterOrder, bool fReset, double dInitialSample)
-{    
-    double output = 0.0f;
-    double tmp    = 0.0f;
-
-    // 1) Check arguments - pointers
-    if ((pA == NULL) || (pB == NULL) || (pIn == NULL) || (pOut == NULL))
-    {
-        return 0;
-    }
-
-    // 2) Check arguments - lengths
-    if ((bFilterOrder == 0) || (aLength == 0) || (bLength == 0) || (aLength > bFilterOrder) || (bLength > bFilterOrder))
-    {
-        return 0;
-    }
-
-    // 3) If fReset was set, modify input data
-    if (fReset)
-    {
-        for (uint8_t i = 0; i < bFilterOrder; i++)
-        {
-            pIn[i]  = dInitialSample;   // Initialize input buffer with initial sample
-            pOut[i] = 0;                // Initialize output buffer with zero
-        }
-    }
-    pIn[bFilterOrder - 1] = dInput;     // Place new input sample at the end of input buffer
-
-    // 4) Apply the feedforward coefficients to the input samples 
-    for (uint8_t i = 0; i < bLength; i++)
-    {
-        tmp += pB[i] * pIn[bFilterOrder - 1 - i];
-    }
-
-    // 5) Apply the feedback coefficients to the output samples
-    for (uint8_t i = 1; i < aLength; i++)
-    {
-        tmp -= pA[i] * pOut[bFilterOrder - 1 - i];
-    }
-
-    // 6) Normalize by the first feedback coefficient 
-    tmp /= pA[0];
-    output = tmp;
+    // 7) Normalize by the first feedback coefficient
+    tmp                    /= pA[0];
+    output                  = tmp;
     pOut[bFilterOrder - 1]  = output;
 
-    // 7) Shift input and output buffers to make room for the next sample
-    for (uint8_t i = 1; i < bFilterOrder; i++)
-    {
-        pIn[i - 1]  = pIn[i];
-        pOut[i - 1] = pOut[i];
-    }
-
     // 8) Return the filtered output sample
     return output;
 }
+

--- a/shared/data_processing.h
+++ b/shared/data_processing.h
@@ -7,6 +7,5 @@
 #include <string.h>
 
 float digital_filter(float dInput, float *pIn, float *pOut, const float *pA, const float *pB, uint8_t aLength, uint8_t bLength, uint8_t bFilterOrder, bool fReset, float dInitialSample);
-double ecgbr_digital_filter(double dInput, double *pIn, double *pOut, const double *pA, const double *pB, uint8_t aLength, uint8_t bLength, uint8_t bFilterOrder, bool fReset, double dInitialSample);
 
 #endif /* DATA_PROCESSING_H_ */


### PR DESCRIPTION
# Summary
Update filter to floats. Match fw implementation to python implementation. Fixed check reset logic. Removed ecgbr_digital_filter (which used doubles).

# Added
- N/A

# Changed
- `ecg_bit_reduction.c` - changed all doubles to floats. used floorf instead of floor. Call `digital_filter` instead of `ecgbr_digital_filter`. Updated `CheckRestartFilter` logic and renamed some variables to clarify purpose and match with python implementation. Add cap to `samples_since_last_high`. Rename some thresholds to match python.
- `main.c` - `bECGReducedData` should be int16_t not uint16_t, clarify when `fECGBufferRefresh` should be used. Add printouts for all three channels.
- `data_processing.c and .h` - removed `ecgbr_digital_filter`

# Removed
- N/A

# Testing
- a 0.17hz rectangular pulse wave (recorded using whaleteq and skiin) was used tested to show that the frequency response of the c filter was acceptable
- example of skiin data BR2_in1_PACE_ID0465_20211004_3ECG_underwear_LyingDown was checked to ensure three channels of ecg matched between python and c
- example of noisy data skiin data was also tested to check that reset occurs at the same time between python and c: BR1_in1_orignial_filtered_processed_1.csv (only one channel), but the logic applies to all three channels.
